### PR TITLE
Use golang as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,10 @@
 # This Dockerfiles configures a container that is used to compile the released
 # restic binaries.
 
-FROM debian:jessie
+FROM golang
 
-ARG GOVERSION=1.8.3
-ARG GOARCH=amd64
-
-# install dependencies
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates wget zip bzip2
-
-# download and install Go
-RUN wget -q -O /tmp/go.tar.gz https://storage.googleapis.com/golang/go${GOVERSION}.linux-${GOARCH}.tar.gz
-RUN cd /usr/local && tar xf /tmp/go.tar.gz && rm -f /tmp/go.tar.gz
-ENV PATH $PATH:/usr/local/go/bin
+RUN apt-get install -y --no-install-recommends bzip2 zip
 
 # add and configure user
 ENV HOME /home/build


### PR DESCRIPTION
The  [official golang image](https://hub.docker.com/_/golang/) should be used rather than installing go in this container.