### PR TITLE
Add support for solaris/amd64 in the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,7 @@ for R in       \
     linux/arm64    \
     openbsd/386   \
     openbsd/amd64 \
+    solaris/amd64 \
     windows/386    \
     windows/amd64  \
     ; do \


### PR DESCRIPTION
After https://github.com/restic/restic/pull/1649 has been merged, upcoming release of restic should include solaris/amd64 binary along with it.