### PR TITLE
Install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN true \
     && apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
+        git \
         gnupg \
         wget \
         zip \


### PR DESCRIPTION
Without git, the build was aborted with the following error message:
```
error obtaining VCS status: exec: "git": executable file not found in $PATH
	Use -buildvcs=false to disable VCS stamping.
```