### PR TITLE
Simplify builder updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN true \
 COPY download.sh /usr/local/bin/
 COPY linux_signing_key.pub .
 
+ARG GO_VERSION=1.20.3
 # download and install go compiler
-RUN chmod 755 /usr/local/bin/download.sh && /usr/local/bin/download.sh
+RUN chmod 755 /usr/local/bin/download.sh && /usr/local/bin/download.sh ${GO_VERSION}
 
 ENV \
     # add go and local binaries to PATH

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ First, clone (or update) this repo:
 
     $ git pull
 
-Second, pull the base image and build the docker container:
+Second, pull the base image and build the docker container using the required Go version:
 
+    $ GO_VERSION=1.20.3
     $ docker pull debian:stable
-    $ docker build --no-cache -t restic/builder .
+    $ docker build --no-cache -t restic/builder:${GO_VERSION} --build-arg GO_VERSION=${GO_VERSION} .
+    $ docker tag restic/builder:${GO_VERSION} restic/builder:latest
 
 Maintainers may also publish the new image to Docker hub:
 
-    $ docker push restic/builder
+    $ docker push restic/builder:${GO_VERSION}
+    $ docker push restic/builder:latest
 
 Next, download and extract the restic source code.
 

--- a/download.sh
+++ b/download.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-latest="1.19.5"
-file="go${latest}.linux-amd64.tar.gz"
+latest="1.20.3"
+file="go${latest}.linux-arm64.tar.gz"
 
 # import GPG key, can be downloaded here:
 # https://dl.google.com/dl/linux/linux_signing_key.pub

--- a/download.sh
+++ b/download.sh
@@ -4,7 +4,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-latest="1.20.3"
+if [[ $# -ne 1 ]]; then
+    echo >&2 "Usage: download.sh GO_VERSION"
+    exit 1
+fi
+
+latest="$1"
 file="go${latest}.linux-arm64.tar.gz"
 
 # import GPG key, can be downloaded here:


### PR DESCRIPTION
The go version is now passed as a build arg, which removes the need to
bump and commit the go version number.

In addition, the container is now tagged with the used go version. This
simplifies reproducing old restic binaries.